### PR TITLE
update to allow user to see files

### DIFF
--- a/jquery-gdrive.js
+++ b/jquery-gdrive.js
@@ -75,7 +75,7 @@
 		$('#'+target_id).val('');
 		var elem_opts = dlgopts[target_id];
 		
-		var view = new google.picker.DocsView(google.picker.ViewId.FOLDERS);
+		var view = new google.picker.DocsView(google.picker.ViewId.DOCS);
 		view.setMode(google.picker.DocsViewMode.LIST);
 		if(elem_opts.filter == 'application/vnd.google-apps.folder') {
 			view.setSelectFolderEnabled(true);


### PR DESCRIPTION
Google updated its API - this means that users can't see files when you instantiate Picker the old way; you just see folders. This proposed fix allows users to see their files again.

Thanks for making this awesome library!